### PR TITLE
Temporary CSS to "kill" multilan plugin dropdown from Cameron.....

### DIFF
--- a/userlanguage_flags_menu.php
+++ b/userlanguage_flags_menu.php
@@ -20,6 +20,9 @@ if(!e107::isInstalled('userlanguage_flags_menu'))
 	e107::redirect(e_BASE . 'index.php');
 }
 
+// Temporary CSS to "kill" multilan plugin dropdown from Cameron.....
+e107::css('inline', '.dropdown.multilan-language { visibility: hidden }');
+
 $pref = e107::pref('userlanguage_flags_menu'); 
 
 unset($text);


### PR DESCRIPTION
Temporary CSS to "kill" multilan plugin dropdown from Cameron.....

When both plugins are installed, Cameron's ALLWAYS displays the dropdown, there's no way to set it off, so the only workaround is to hidde it via css.....

Makes nosense to have two language dropdowns....